### PR TITLE
Change nginx base to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:1.21.6
+FROM nginx:alpine
 COPY ./out /usr/share/nginx/html


### PR DESCRIPTION
Changed Nginx to use Alpine instead of Debian
Image size is 93 MB smaller and build times are shorter is 36-49s now is 23-36s.


Have been running the latest version built on nginx:alpine on my raspi for the day and nothing seems to be broken. Only add services with no API, so that's the only thing I haven't tested as I don't have one

Will be making alpine builds in my fork till this has been tested more and merged.

```
ghcr.io/c00ldude1oo/mhp           test             ec30655a4d49   35 minutes ago      19.7MB
ghcr.io/ajnart/mhp                latest           afa7d0ba6d4d   10 hours ago        113MB
```
